### PR TITLE
Cancel previous ripple on click

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -28,7 +28,7 @@ CSS.paintWorklet.addModule('./ripple-worklet.js');
 
 if (!window.performance) window.performance = { now: Date.now.bind(Date) };
 
-if (!window.requestAnimationFrame) window.requestAnimationFrame = function(cb) { return setTimeout(doAnim, cb); };
+if (!window.requestAnimationFrame) window.requestAnimationFrame = function(cb) { return setTimeout(doAnim, 16, cb); };
 function doAnim(cb) { cb(performance.now()); }
 
 function ripple(button, evt) {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -28,7 +28,10 @@ CSS.paintWorklet.addModule('./ripple-worklet.js');
 
 if (!window.performance) window.performance = { now: Date.now.bind(Date) };
 
-if (!window.requestAnimationFrame) window.requestAnimationFrame = function(cb) { return setTimeout(doAnim, 16, cb); };
+if (!window.requestAnimationFrame) {
+	window.requestAnimationFrame = function(cb) { return setTimeout(doAnim, 16, cb); };
+	window.cancelAnimationFrame = function(req) { clearTimeout(req); }
+}
 function doAnim(cb) { cb(performance.now()); }
 
 function ripple(button, evt) {


### PR DESCRIPTION
## Steps to reproduce
1. Go to the [demo page](https://googlechromelabs.github.io/css-paint-polyfill/).
2. Click the big "Click me!" button. The ripple effect starts.
3. Before the ripple finishes, click the same button again.

## Expected results
The current ripple stops and a new ripple starts. After 1 second, the new ripple fills the entire button and then disappears.

## Actual results
The current ripple stops and a new ripple starts. However, the new ripple disappears before it fills the entire button. In fact, it disappears when the *first* ripple would have finished its animation.

## Solution
When starting a new ripple effect, cancel any pending previous effect using `cancelAnimationFrame`. (And add a polyfill for this function if it's not supported natively.)

I also noticed that the `requestAnimationFrame` "polyfill" was incorrect: the `setTimeout` call was missing the `delay`. However, this is still not enough to get the demo working on IE11... 😕 