### PR TITLE
Experimental animation tracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1004,7 +1004,6 @@ function init() {
 		'animationstart',
 		'transitionstart',
 		'transitionend',
-		'transitionrun',
 		'transitioncancel',
 		'mouseover',
 		'mouseout',
@@ -1018,6 +1017,25 @@ function init() {
 
 	function updateFromEvent(e) {
 		let t = e.target;
+		const type = e.type;
+		if (type === 'animationstart' || type === 'transitionstart') {
+			const s = this.$$paintAnimating = (this.$$paintAnimating || 0) + 1;
+			if (s === 1) {
+				// Firefox ~68 didn't support Event.path
+				const p = [];
+				do { if (t.nodeType === 1) p.push(t); } while ((t = t.parentNode));
+				let frame = () => {
+					if (!this.$$paintAnimating) return frame = null;
+					for (let i=p.length; i--; ) queueUpdate(p[i]);
+					this.$$paintRaf = (self.requestAnimationFrame || Object)(frame);
+				};
+				frame();
+			}
+			return;
+		}
+		if ((type === 'animationend' || type === 'transitionend' || type === 'transitioncancel') && --this.$$paintAnimating === 0) {
+			(self.cancelAnimationFrame || Object)(this.$$paintRaf);
+		}
 		while (t) {
 			if (t.nodeType === 1) queueUpdate(t);
 			t = t.parentNode;

--- a/src/index.js
+++ b/src/index.js
@@ -1026,8 +1026,8 @@ function init() {
 				do { if (t.nodeType === 1) p.push(t); } while ((t = t.parentNode));
 				let frame = () => {
 					if (!this.$$paintAnimating) return frame = null;
-					for (let i=p.length; i--; ) queueUpdate(p[i]);
 					this.$$paintRaf = (self.requestAnimationFrame || Object)(frame);
+					for (let i=p.length; i--; ) queueUpdate(p[i]);
 				};
 				frame();
 			}


### PR DESCRIPTION
This tracks animation state and runs a frame loop to update painted elements that are affected by transition/animation changes. It's pretty slow though, and these browsers don't provide "rendered values" for animating/transitioning custom properties anyway. The result is basically that the polyfill triggers a bunch of painter updates, none of which are useful.


### Without tracking:

<img width="500" src="https://user-images.githubusercontent.com/105127/97519838-4c2d4980-1970-11eb-9c92-0f285f546cff.gif">

### With tracking:

<img width="500" src="https://user-images.githubusercontent.com/105127/97519847-53ecee00-1970-11eb-87b3-6708e9841d68.gif">
